### PR TITLE
Add support for default values in Forms4s

### DIFF
--- a/forms4s-core/src/main/scala/forms4s/DefaultValues.scala
+++ b/forms4s-core/src/main/scala/forms4s/DefaultValues.scala
@@ -1,0 +1,41 @@
+package forms4s
+
+import scala.quoted.*
+
+object DefaultValues {
+  
+  inline def extract[T]: Map[String, Any] = ${ extractImpl[T] }
+
+  private def extractImpl[T](using quotes: Quotes, tpe: Type[T]): Expr[Map[String, Any]] = {
+    import quotes.reflect.*
+    
+    val sym = TypeTree.of[T].symbol
+    
+    // Get the companion module
+    val companionSym = sym.companionModule
+    if (companionSym == Symbol.noSymbol) {
+      return '{ Map.empty[String, Any] }
+    }
+    
+    val comp = sym.companionClass
+    val mod = Ref(companionSym)
+    
+    // Get field names that have defaults
+    val names = sym.caseFields.filter(p => p.flags.is(Flags.HasDefault)).map(_.name)
+    
+    val namesExpr: Expr[List[String]] = Expr.ofList(names.map(Expr(_)))
+    
+    // Get the companion class body
+    val body = comp.tree.asInstanceOf[ClassDef].body
+    
+    // Find default value methods ($lessinit$greater$default$N)
+    val idents: List[Ref] = body.collect {
+      case deff @ DefDef(name, _, _, _) if name.startsWith("$lessinit$greater$default") =>
+        mod.select(deff.symbol)
+    }
+    
+    val identsExpr: Expr[List[Any]] = Expr.ofList(idents.map(_.asExpr))
+    
+    '{ $namesExpr.zip($identsExpr).toMap }
+  }
+}

--- a/forms4s-core/src/main/scala/forms4s/FormElement.scala
+++ b/forms4s-core/src/main/scala/forms4s/FormElement.scala
@@ -49,6 +49,6 @@ object FormElement {
     case class State(selected: Int, states: Vector[FormElementState])
   }
 
-  case class Core[-T](id: String, label: String, description: Option[String], validators: Seq[Validator[T]])
+  case class Core[-T](id: String, label: String, description: Option[String], validators: Seq[Validator[T]], defaultValue: Option[Any] = None)
 
 }

--- a/forms4s-core/src/main/scala/forms4s/ToFormElem.scala
+++ b/forms4s-core/src/main/scala/forms4s/ToFormElem.scala
@@ -48,6 +48,7 @@ object ToFormElem {
     // get compile-time labels & ToFormElem instances
     val labels = elemLabels[p.MirroredElemLabels]
     val elems  = summonAll[p.MirroredElemTypes]
+    val defaults = DefaultValues.extract[T]
 
     // build a Group
     StaticToFormElem(
@@ -60,8 +61,9 @@ object ToFormElem {
         ),
         elements = elems.zip(labels).map { (tf, name) =>
           val fe = tf.get
+          val defaultValue = defaults.get(name)
           // copy into each element its field‐name as id & human label
-          updateCore(fe)(id = name, label = name.capitalize)
+          updateCore(fe)(id = name, label = name.capitalize, defaultValue = defaultValue)
         },
       ),
     )
@@ -101,13 +103,13 @@ object ToFormElem {
     }
 
   // –– Helpers: update the Core.id & Core.label of any FormElement –––
-  private def updateCore(fe: FormElement)(id: String, label: String): FormElement = fe match {
-    case Text(core, fmt)          => Text(core.copy(id = id, label = label), fmt)
-    case Number(core, isInt)      => Number(core.copy(id = id, label = label), isInt)
-    case Select(core, opts)       => Select(core.copy(id = id, label = label), opts)
-    case Checkbox(core)           => Checkbox(core.copy(id = id, label = label))
-    case Group(core, elems)       => Group(core.copy(id = id, label = label), elems)
-    case Multivalue(core, item)   => Multivalue(core.copy(id = id, label = label), item)
-    case Alternative(core, vs, d) => Alternative(core.copy(id = id, label = label), vs, d)
+  private def updateCore(fe: FormElement)(id: String, label: String, defaultValue: Option[Any]): FormElement = fe match {
+    case Text(core, fmt)          => Text(core.copy(id = id, label = label, defaultValue = defaultValue), fmt)
+    case Number(core, isInt)      => Number(core.copy(id = id, label = label, defaultValue = defaultValue), isInt)
+    case Select(core, opts)       => Select(core.copy(id = id, label = label, defaultValue = defaultValue), opts)
+    case Checkbox(core)           => Checkbox(core.copy(id = id, label = label, defaultValue = defaultValue))
+    case Group(core, elems)       => Group(core.copy(id = id, label = label, defaultValue = defaultValue), elems)
+    case Multivalue(core, item)   => Multivalue(core.copy(id = id, label = label, defaultValue = defaultValue), item)
+    case Alternative(core, vs, d) => Alternative(core.copy(id = id, label = label, defaultValue = defaultValue), vs, d)
   }
 }

--- a/forms4s-jsonschema/src/main/scala/forms4s/jsonschema/FormFromJsonSchema.scala
+++ b/forms4s-jsonschema/src/main/scala/forms4s/jsonschema/FormFromJsonSchema.scala
@@ -90,7 +90,13 @@ object FormFromJsonSchema {
   ): Ior[List[String], FormElement] = {
     val name                                   = nameOverride.getOrElse(schema.title.getOrElse("unknown"))
     val label                                  = schema.title.getOrElse(capitalizeAndSplitWords(name))
-    def core[T](validators: Seq[Validator[T]]) = FormElement.Core(name, label, schema.description, validators)
+
+    val defaultValue = schema.default.flatMap {
+      case ExampleSingleValue(v) => Some(v)
+      case _                     => None
+    }
+
+    def core[T](validators: Seq[Validator[T]]) = FormElement.Core(name, label, schema.description, validators, defaultValue)
 
     val variants = schema.oneOf ++ schema.anyOf
     if (variants.nonEmpty) {

--- a/forms4s-jsonschema/src/test/scala/forms4s/jsonschema/FormFromJsonSchemaSpec.scala
+++ b/forms4s-jsonschema/src/test/scala/forms4s/jsonschema/FormFromJsonSchemaSpec.scala
@@ -237,6 +237,33 @@ class FormFromJsonSchemaSpec extends AnyFreeSpec {
       }
     }
 
+    "default values" in {
+      import sttp.apispec.{Schema => ASchema, ExampleSingleValue, SchemaType}
+      import scala.collection.immutable.ListMap
+
+      val schema = ASchema(
+        title = Some("WithDefaults"),
+        `type` = Some(List(SchemaType.Object)),
+        properties = ListMap(
+          "a" -> ASchema(
+            `type` = Some(List(SchemaType.String)),
+            default = Some(ExampleSingleValue("default"))
+          )
+        )
+      )
+      
+      val form = FormFromJsonSchema.convert(schema)
+
+      val expected = FormElement.Group(
+        simpleCore("WithDefaults"),
+        List(
+          FormElement.Text(simpleCore("a", "A").copy(defaultValue = Some("default")), Format.Raw),
+        ),
+      )
+
+      assert(form == expected)
+    }
+
   }
 
   def getForm[T](nullableOptions: Boolean = false)(implicit tschema: TSchema[T]): FormElement = {


### PR DESCRIPTION
implements support for default values in both Scala-derived forms and JSON Schema-derived forms. It ensures that default values defined in case classes or JSON schemas are correctly used to pre-fill forms on creation

forms4s-jsonschema:
Updated 
FormFromJsonSchema.scala
 to extract the default value from JSON Schema properties (specifically handling ExampleSingleValue) and pass it to the FormElement core.
Added a new test case in 
FormFromJsonSchemaSpec.scala
 to verify that default values from a JSON schema are correctly propagated to the generated form elements.
 
 all tests passed 
solve issue #8  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added support for default values in form elements.
  * Automatically derives defaults from case class parameters.
  * Reads and applies defaults from JSON Schema definitions.
  * Form initialization now populates fields with their configured defaults.

* Tests
  * Added tests verifying default value propagation in generated form elements.
  * Added tests ensuring initial form state reflects specified defaults from models and JSON Schema.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->